### PR TITLE
Extract correct library version for Python 3.6 on Linux

### DIFF
--- a/R/config.R.in
+++ b/R/config.R.in
@@ -21,7 +21,7 @@ py_config <- function() {
   }
   
   # extract python library from PKG_LIBS
-  match <- regexpr("-lpython\\d+\\.\\d+", PKG_LIBS)
+  match <- regexpr("-lpython\\d+\\.\\d+m?", PKG_LIBS)
   if (match == -1)
     stop("Unable to parse -lpython from ", PKG_LIBS)
   libpython_lib <- regmatches(PKG_LIBS, match)


### PR DESCRIPTION
Apparently, the version on Linux uses 3.6m as the version strings which
was not extracted previously.

This *should* not create a regression because there will most likely be
a dot (.) or other separator after the version number even in the case
that the shared library extension or anything else that might come after
the version number contains an "m".