### PR TITLE
Solve Issue #54

### DIFF
--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -107,7 +107,7 @@ find_spacy <- function(model = "en"){
     }
     options(warn = 0)
     
-    if (length(py_execs) == 0){
+    if (length(py_execs) == 0 | grepl("not find", py_execs[1])[1]){
         stop("No python was found on system PATH")
     }
     df_python_check <- data.table::data.table(py_execs, spacy_found = 0)

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -97,13 +97,19 @@ spacy_finalize <- function() {
 #' @keywords internal
 #' @importFrom data.table data.table
 find_spacy <- function(model = "en"){
-    spacy_python <- spacy_found <- `:=` <- NA
+    spacy_found <- `:=` <- NA
+    spacy_python <- NULL
+    options(warn = -1)
     py_execs <- if(Sys.info()['sysname'] == "Windows") {
         system2("where", "python", stdout = TRUE)
     } else {
         system2('which', '-a python', stdout = TRUE)
     }
-
+    options(warn = 0)
+    
+    if (length(py_execs) == 0){
+        stop("No python was found on system PATH")
+    }
     df_python_check <- data.table::data.table(py_execs, spacy_found = 0)
     for(i in 1:nrow(df_python_check)) {
         py_exec <- df_python_check[i, py_execs]
@@ -112,9 +118,9 @@ find_spacy <- function(model = "en"){
             df_python_check[i, spacy_found := 1]
         }
     }
-
+    
     if (df_python_check[, sum(spacy_found)] == 0) {
-        1
+        return(NULL)
     } else if(df_python_check[, sum(spacy_found)] == 1) {
         spacy_python <- df_python_check[spacy_found == 1, py_execs]
         message("spaCy (language model: ", model, ") is installed in ", spacy_python)


### PR DESCRIPTION
Updated the error handling of `spacy_initialize()` (Issue #54).

For a system without `spaCy` (but with Python) it will return the following (tested on a virtual Ubuntu 14.04).
```{r}
> library(spacyr)
> spacy_initialize()
Finding a python executable with spacy installed...
Error in spacy_initialize() : 
  spaCy or language model en is not installed in any of python executables.
```
For a system without python, it will return the following (tested on a virtual Windows 10):

```{r}
> library(spacyr)
> spacy_initialize()
Finding a python executable with spacy installed...
Error in find_spacy(model) : No python was found on system PATH
```
