### PR TITLE
add ask option to spacy_initialize

### DIFF
--- a/man/find_spacy.Rd
+++ b/man/find_spacy.Rd
@@ -4,10 +4,15 @@
 \alias{find_spacy}
 \title{Find spaCy}
 \usage{
-find_spacy(model = "en")
+find_spacy(model = "en", ask)
 }
 \arguments{
 \item{model}{name of the language model}
+
+\item{ask}{logical; if \code{FALSE}, use the first spaCy installation found; 
+if \code{TRUE}, list available spaCy installations and prompt the user 
+for which to use. If another (e.g. \code{python_executable}) is set, then 
+this value will always be treated as \code{FALSE}.}
 }
 \value{
 spacy_python

--- a/man/spacy_initialize.Rd
+++ b/man/spacy_initialize.Rd
@@ -4,7 +4,7 @@
 \alias{spacy_initialize}
 \title{Initialize spaCy}
 \usage{
-spacy_initialize(model = "en", python_executable = NULL,
+spacy_initialize(model = "en", python_executable = NULL, ask = FALSE,
   virtualenv = NULL, condaenv = NULL)
 }
 \arguments{
@@ -12,6 +12,11 @@ spacy_initialize(model = "en", python_executable = NULL,
 \code{de} (German). Default is \code{en}.}
 
 \item{python_executable}{the full path to the python excutable, for which spaCy is installed}
+
+\item{ask}{logical; if \code{FALSE}, use the first spaCy installation found; 
+if \code{TRUE}, list available spaCy installations and prompt the user 
+for which to use. If another (e.g. \code{python_executable}) is set, then 
+this value will always be treated as \code{FALSE}.}
 
 \item{virtualenv}{set a path to the python virtual environment with spaCy installed
 Example: \code{virtualenv = "~/myenv"}}


### PR DESCRIPTION
To address issue #78. If `ask = FALSE` and there are more than one python executables, `spacyr` will return a message like this 

```
> spacy_initialize()
Finding a python executable with spacy installed...
spaCy (language model: en) is installed in more than one python
spacyr will use /usr/local/bin/python (because ask = FALSE)
successfully initialized (spaCy Version: 1.8.2, language model: en)
```