### PR TITLE
add source_bash_profile option to spacy_initialize

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spacyr
 Type: Package
-Version: 0.9.3
+Version: 0.9.4
 Title: Wrapper to the 'spaCy 'NLP' Library
 Authors@R: c( person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role =
     c("aut", "cre", "cph")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
+# v0.9.4
+
+* Now looks for Python settings from `.bash_profile`.
+
 # v0.9.3
 
 * Updated for the newer spaCy 2.0 release and new language models.
-* Add`ask = FAlSE` to `spacy_initialize()`.
+* Add `ask = FALSE` to `spacy_initialize()`, to find spaCy installations automatically.
 
 # v0.9.2
 

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -11,7 +11,9 @@
 #'   this value will always be treated as \code{FALSE}.
 #' @param source_bash_profile logical; if \code{TRUE}, source \code{~/.bash_profile} before trying
 #'   to find python executables with spaCy installed. Most likely necessary to set \code{TRUE}, 
-#'   if using anaconda python in Mac or Linux. 
+#'   if using anaconda python in Mac or Linux. Default is \code{NULL} 
+#'   which functions as \code{TRUE} for non-Windows system (e.g. Mac/Linux) and 
+#'   \code{FALSE} for Windows system.
 #' @param virtualenv set a path to the python virtual environment with spaCy installed
 #'   Example: \code{virtualenv = "~/myenv"}
 #' @param condaenv set a path to the anaconda virtual environment with spaCy installed
@@ -21,7 +23,7 @@
 spacy_initialize <- function(model = "en", 
                              python_executable = NULL,
                              ask = FALSE,
-                             source_bash_profile = FALSE,
+                             source_bash_profile = NULL,
                              virtualenv = NULL,
                              condaenv = NULL) {
 
@@ -29,6 +31,13 @@ spacy_initialize <- function(model = "en",
     if(!is.null(options("spacy_initialized")$spacy_initialized)){
         message("spaCy is already initialized")
         return(NULL)
+    }
+    if(is.null(source_bash_profile)) {
+        if(Sys.info()['sysname'] == "Windows"){
+            source_bash_profile <- FALSE
+        } else {
+            source_bash_profile <- TRUE
+        }
     }
     # once python is initialized, you cannot change the python executables
     if(!is.null(options("python_initialized")$python_initialized)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -185,23 +185,23 @@ spacy_finalize()
 ```
 By calling `spacy_initialize()` again, you can restart the backend spaCy.
 
-### Permanetly set the default spacy
+### Permanently set the default python
 
-If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to spacy by spacifying it in an R-startup file, which will be read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for 
+If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to the spacy python by spacifying it in an R-startup file, which is read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for 
 
 The syntax is:
 ```{R eval = FALSE}
 options(spacy_python_setting = list(type = "python_executable",
                                     py_path = "/the/path/to/python")) # e.g. "/usr/local/bin/python"
 ```
-These line can be put directly by a text-editor or from `R`, enter the following (for Mac/Linux)
+These lines can be directly inserted by a text-editor. Or from `R`, enter the following (for Mac/Linux):
 ```{R eval = FALSE}
 option_string <- 'options(spacy_python_setting = list(type = "python_executable",
                                     py_path = "/the/path/to/python")) '
 write(option_string, file = "~/.Rprofile", append = TRUE)
 ```
 
-Once it is appropriately set up the message from `spacy_initialize()` changes to something like:
+Once the file is appropriately set up, the message from `spacy_initialize()` changes to something like:
 ```
 ## The python path is already set
 ## spacyr will use: python_executable = /usr/local/bin/python

--- a/README.Rmd
+++ b/README.Rmd
@@ -185,6 +185,29 @@ spacy_finalize()
 ```
 By calling `spacy_initialize()` again, you can restart the backend spaCy.
 
+### Permanetly set the default spacy
+
+If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to spacy by spacifying it in an R-startup file, which will be read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for 
+
+The syntax is:
+```{R eval = FALSE}
+options(spacy_python_setting = list(type = "python_executable",
+                                    py_path = "/the/path/to/python")) # e.g. "/usr/local/bin/python"
+```
+These line can be put directly by a text-editor or from `R`, enter the following (for Mac/Linux)
+```{R eval = FALSE}
+option_string <- 'options(spacy_python_setting = list(type = "python_executable",
+                                    py_path = "/the/path/to/python")) '
+write(option_string, file = "~/.Rprofile", append = TRUE)
+```
+
+Once it is appropriately set up the message from `spacy_initialize()` changes to something like:
+```
+## The python path is already set
+## spacyr will use: python_executable = /usr/local/bin/python
+## successfully initialized (spaCy Version: 2.0.1, language model: en)
+```
+
 
 ## Using **spacyr** with other packages
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -185,16 +185,16 @@ spacy_finalize()
 ```
 By calling `spacy_initialize()` again, you can restart the backend spaCy.
 
-### Permanently set the default python
+### Permanently seting the default Python
 
-If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to the spacy python by spacifying it in an R-startup file, which is read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for 
+If you want to skip **spacyr** searching for Python intallation with spaCy, you can do so by permanently setting the path to the spaCy-enabled Python by specifying it in an R-startup file, which is read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for 
 
 The syntax is:
 ```{R eval = FALSE}
 options(spacy_python_setting = list(type = "python_executable",
                                     py_path = "/the/path/to/python")) # e.g. "/usr/local/bin/python"
 ```
-These lines can be directly inserted by a text-editor. Or from `R`, enter the following (for Mac/Linux):
+These lines can be directly inserted by a text editor.  Or from R, enter the following (for Mac/Linux):
 ```{R eval = FALSE}
 option_string <- 'options(spacy_python_setting = list(type = "python_executable",
                                     py_path = "/the/path/to/python")) '

--- a/README.md
+++ b/README.md
@@ -353,9 +353,9 @@ spacy_finalize()
 
 By calling `spacy_initialize()` again, you can restart the backend spaCy.
 
-### Permanetly set the default spacy
+### Permanently set the default python
 
-If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to spacy by spacifying it in an R-startup file, which will be read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for
+If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to the spacy python by spacifying it in an R-startup file, which is read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for
 
 The syntax is:
 
@@ -364,7 +364,7 @@ options(spacy_python_setting = list(type = "python_executable",
                                     py_path = "/the/path/to/python")) # e.g. "/usr/local/bin/python"
 ```
 
-These line can be put directly by a text-editor or from `R`, enter the following (for Mac/Linux)
+These lines can be directly inserted by a text-editor. Or from `R`, enter the following (for Mac/Linux):
 
 ``` r
 option_string <- 'options(spacy_python_setting = list(type = "python_executable",
@@ -372,7 +372,7 @@ option_string <- 'options(spacy_python_setting = list(type = "python_executable"
 write(option_string, file = "~/.Rprofile", append = TRUE)
 ```
 
-Once it is appropriately set up the message from `spacy_initialize()` changes to something like:
+Once the file is appropriately set up, the message from `spacy_initialize()` changes to something like:
 
     ## The python path is already set
     ## spacyr will use: python_executable = /usr/local/bin/python

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ spacy_initialize()
 ## Finding a python executable with spacy installed...
 ## spaCy (language model: en) is installed in more than one python
 ## spacyr will use /usr/local/bin/python (because ask = FALSE)
-## successfully initialized (spaCy Version: 1.8.2, language model: en)
+## successfully initialized (spaCy Version: 2.0.1, language model: en)
 ```
 
 ### Tokenizing and tagging texts
@@ -114,8 +114,8 @@ txt <- c(d1 = "spaCy excels at large-scale information extraction tasks.",
 parsedtxt <- spacy_parse(txt)
 parsedtxt
 ##    doc_id sentence_id token_id       token       lemma   pos   entity
-## 1      d1           1        1       spaCy       spacy  NOUN         
-## 2      d1           1        2      excels       excel  VERB         
+## 1      d1           1        1       spaCy       spacy   ADJ         
+## 2      d1           1        2      excels       excel  NOUN         
 ## 3      d1           1        3          at          at   ADP         
 ## 4      d1           1        4       large       large   ADJ         
 ## 5      d1           1        5           -           - PUNCT         
@@ -138,8 +138,8 @@ Two fields are available for part-of-speech tags. The `pos` field returned is th
 ``` r
 spacy_parse(txt, tag = TRUE, entity = FALSE, lemma = FALSE)
 ##    doc_id sentence_id token_id       token   pos  tag
-## 1      d1           1        1       spaCy  NOUN   NN
-## 2      d1           1        2      excels  VERB  VBZ
+## 1      d1           1        1       spaCy   ADJ   JJ
+## 2      d1           1        2      excels  NOUN  NNS
 ## 3      d1           1        3          at   ADP   IN
 ## 4      d1           1        4       large   ADJ   JJ
 ## 5      d1           1        5           - PUNCT HYPH
@@ -183,8 +183,8 @@ Or, convert multi-word entities into single "tokens":
 ``` r
 entity_consolidate(parsedtxt)
 ##    doc_id sentence_id token_id          token    pos entity_type
-## 1      d1           1        1          spaCy   NOUN            
-## 2      d1           1        2         excels   VERB            
+## 1      d1           1        1          spaCy    ADJ            
+## 2      d1           1        2         excels   NOUN            
 ## 3      d1           1        3             at    ADP            
 ## 4      d1           1        4          large    ADJ            
 ## 5      d1           1        5              -  PUNCT            
@@ -213,8 +213,8 @@ spacy_parse(txt, dependency = TRUE, lemma = FALSE, pos = FALSE)
 ## 3      d1           1        3          at             2     prep         
 ## 4      d1           1        4       large             6     amod         
 ## 5      d1           1        5           -             6    punct         
-## 6      d1           1        6       scale             7 compound         
-## 7      d1           1        7 information             9 compound         
+## 6      d1           1        6       scale             9 compound         
+## 7      d1           1        7 information             8 compound         
 ## 8      d1           1        8  extraction             9 compound         
 ## 9      d1           1        9       tasks             3     pobj         
 ## 10     d1           1       10           .             2    punct         
@@ -247,14 +247,14 @@ This is an example of parsing German texts.
 spacy_finalize()
 spacy_initialize(model = "de")
 ## Python space is already attached.  If you want to swtich to a different Python, please restart R.
-## successfully initialized (spaCy Version: 1.8.2, language model: de)
+## successfully initialized (spaCy Version: 2.0.1, language model: de)
 
 txt_german <- c(R = "R ist eine freie Programmiersprache für statistische Berechnungen und Grafiken. Sie wurde von Statistikern für Anwender mit statistischen Aufgaben entwickelt.",
                python = "Python ist eine universelle, üblicherweise interpretierte höhere Programmiersprache. Sie will einen gut lesbaren, knappen Programmierstil fördern.")
 results_german <- spacy_parse(txt_german, dependency = TRUE, lemma = FALSE, tag = TRUE)
 results_german
 ##    doc_id sentence_id token_id              token   pos   tag
-## 1       R           1        1                  R     X    XY
+## 1       R           1        1                  R PROPN    NE
 ## 2       R           1        2                ist   AUX VAFIN
 ## 3       R           1        3               eine   DET   ART
 ## 4       R           1        4              freie   ADJ  ADJA
@@ -276,7 +276,7 @@ results_german
 ## 20      R           2        9           Aufgaben  NOUN    NN
 ## 21      R           2       10         entwickelt  VERB  VVPP
 ## 22      R           2       11                  . PUNCT    $.
-## 23 python           1        1             Python PROPN    NE
+## 23 python           1        1             Python  NOUN    NN
 ## 24 python           1        2                ist   AUX VAFIN
 ## 25 python           1        3               eine   DET   ART
 ## 26 python           1        4        universelle   ADJ  ADJA
@@ -294,50 +294,50 @@ results_german
 ## 38 python           2        6                  , PUNCT    $,
 ## 39 python           2        7            knappen   ADJ  ADJA
 ## 40 python           2        8    Programmierstil  NOUN    NN
-## 41 python           2        9            fördern  VERB VVINF
+## 41 python           2        9            fördern  VERB VVFIN
 ## 42 python           2       10                  . PUNCT    $.
-##    head_token_id dep_rel   entity
-## 1              2      sb         
-## 2              2    ROOT         
-## 3              5      nk         
-## 4              5      nk         
-## 5              2      pd         
-## 6              5     mnr         
-## 7              8      nk         
-## 8              6      nk         
-## 9              8      cd         
-## 10             9      cj         
-## 11             2   punct         
-## 12             2      sb         
-## 13             2    ROOT         
-## 14            10     sbp         
-## 15             3      nk         
-## 16             4     mnr         
-## 17             5      nk         
-## 18            10      mo         
-## 19             9      nk         
-## 20             7      nk         
-## 21             2      oc         
-## 22             2   punct         
-## 23             2      sb PERSON_B
-## 24             2    ROOT         
-## 25             9      nk         
-## 26             9      nk         
-## 27             4   punct         
-## 28             7      mo         
-## 29             4      cj         
-## 30             4  cj||cj         
-## 31             2      pd         
-## 32             2   punct         
-## 33             2      sb         
-## 34             2    ROOT         
-## 35             8      nk         
-## 36             5      mo         
-## 37             8      nk         
-## 38             5   punct         
-## 39             5      cj         
-## 40             9      oa         
-## 41             2      oc         
+##    head_token_id dep_rel entity
+## 1              2      sb       
+## 2              2    ROOT       
+## 3              5      nk       
+## 4              5      nk       
+## 5              2      pd       
+## 6              5     mnr       
+## 7              8      nk       
+## 8              6      nk       
+## 9              8      cd       
+## 10             9      cj       
+## 11             2   punct       
+## 12             2      sb       
+## 13             2    ROOT       
+## 14            10     sbp       
+## 15             3      nk  LOC_B
+## 16             4     mnr       
+## 17             5      nk       
+## 18            10      mo       
+## 19             9      nk       
+## 20             7      nk       
+## 21             2      oc       
+## 22             2   punct       
+## 23             2      sb MISC_B
+## 24             2    ROOT       
+## 25             9      nk       
+## 26             9      nk       
+## 27             4   punct       
+## 28             7      mo       
+## 29             4      cj       
+## 30             9      nk       
+## 31             2      pd       
+## 32             2   punct       
+## 33             2      sb       
+## 34             2    ROOT       
+## 35             8      nk       
+## 36             5      mo       
+## 37             8      nk       
+## 38             5   punct       
+## 39             5      cj       
+## 40             9      oa       
+## 41             2      oc       
 ## 42             2   punct
 ```
 
@@ -353,6 +353,31 @@ spacy_finalize()
 
 By calling `spacy_initialize()` again, you can restart the backend spaCy.
 
+### Permanetly set the default spacy
+
+If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to spacy by spacifying it in an R-startup file, which will be read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for
+
+The syntax is:
+
+``` r
+options(spacy_python_setting = list(type = "python_executable",
+                                    py_path = "/the/path/to/python")) # e.g. "/usr/local/bin/python"
+```
+
+These line can be put directly by a text-editor or from `R`, enter the following (for Mac/Linux)
+
+``` r
+option_string <- 'options(spacy_python_setting = list(type = "python_executable",
+                                    py_path = "/the/path/to/python")) '
+write(option_string, file = "~/.Rprofile", append = TRUE)
+```
+
+Once it is appropriately set up the message from `spacy_initialize()` changes to something like:
+
+    ## The python path is already set
+    ## spacyr will use: python_executable = /usr/local/bin/python
+    ## successfully initialized (spaCy Version: 2.0.1, language model: en)
+
 Using **spacyr** with other packages
 ------------------------------------
 
@@ -362,8 +387,8 @@ Some of the token- and type-related standard methods from [**quanteda**](http://
 
 ``` r
 require(quanteda, warn.conflicts = FALSE, quietly = TRUE)
-## quanteda version 0.99.9004
-## Using 3 of 4 threads for parallel computing
+## quanteda version 0.99.9003
+## Using 7 of 8 threads for parallel computing
 docnames(parsedtxt)
 ## [1] "d1" "d2"
 ndoc(parsedtxt)

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ library("spacyr")
 spacy_initialize()
 ## Finding a python executable with spacy installed...
 ## spaCy (language model: en) is installed in more than one python
-## spacyr will use /usr/local/bin/python (because ask = FALSE)
-## successfully initialized (spaCy Version: 2.0.1, language model: en)
+## spacyr will use /anaconda/bin/python (because ask = FALSE)
+## successfully initialized (spaCy Version: 2.0.2, language model: en)
 ```
 
 ### Tokenizing and tagging texts
@@ -247,7 +247,7 @@ This is an example of parsing German texts.
 spacy_finalize()
 spacy_initialize(model = "de")
 ## Python space is already attached.  If you want to swtich to a different Python, please restart R.
-## successfully initialized (spaCy Version: 2.0.1, language model: de)
+## successfully initialized (spaCy Version: 2.0.2, language model: de)
 
 txt_german <- c(R = "R ist eine freie Programmiersprache für statistische Berechnungen und Grafiken. Sie wurde von Statistikern für Anwender mit statistischen Aufgaben entwickelt.",
                python = "Python ist eine universelle, üblicherweise interpretierte höhere Programmiersprache. Sie will einen gut lesbaren, knappen Programmierstil fördern.")
@@ -353,9 +353,9 @@ spacy_finalize()
 
 By calling `spacy_initialize()` again, you can restart the backend spaCy.
 
-### Permanently set the default python
+### Permanently seting the default Python
 
-If you want to skip `spacyr` to search for python with spacy, you can do so by permanently set the path to the spacy python by spacifying it in an R-startup file, which is read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for
+If you want to skip **spacyr** searching for Python intallation with spaCy, you can do so by permanently setting the path to the spaCy-enabled Python by specifying it in an R-startup file, which is read every time a new `R` is launched. For Mac/Linux, the file is `~/.Rprofile` and for
 
 The syntax is:
 
@@ -364,7 +364,7 @@ options(spacy_python_setting = list(type = "python_executable",
                                     py_path = "/the/path/to/python")) # e.g. "/usr/local/bin/python"
 ```
 
-These lines can be directly inserted by a text-editor. Or from `R`, enter the following (for Mac/Linux):
+These lines can be directly inserted by a text editor. Or from R, enter the following (for Mac/Linux):
 
 ``` r
 option_string <- 'options(spacy_python_setting = list(type = "python_executable",
@@ -387,8 +387,8 @@ Some of the token- and type-related standard methods from [**quanteda**](http://
 
 ``` r
 require(quanteda, warn.conflicts = FALSE, quietly = TRUE)
-## quanteda version 0.99.9003
-## Using 7 of 8 threads for parallel computing
+## quanteda version 0.99.22
+## Using 3 of 4 threads for parallel computing
 docnames(parsedtxt)
 ## [1] "d1" "d2"
 ndoc(parsedtxt)

--- a/man/find_spacy.Rd
+++ b/man/find_spacy.Rd
@@ -4,7 +4,7 @@
 \alias{find_spacy}
 \title{Find spaCy}
 \usage{
-find_spacy(model = "en", ask)
+find_spacy(model = "en", ask, source_bash_profile)
 }
 \arguments{
 \item{model}{name of the language model}
@@ -13,6 +13,10 @@ find_spacy(model = "en", ask)
 if \code{TRUE}, list available spaCy installations and prompt the user 
 for which to use. If another (e.g. \code{python_executable}) is set, then 
 this value will always be treated as \code{FALSE}.}
+
+\item{source_bash_profile}{logical; if \code{TRUE}, source \code{~/.bash_profile} before trying
+to find python executables with spaCy installed. Most likely necessary to set \code{TRUE}, 
+if using anaconda python in Mac or Linux.}
 }
 \value{
 spacy_python

--- a/man/spacy_initialize.Rd
+++ b/man/spacy_initialize.Rd
@@ -5,7 +5,7 @@
 \title{Initialize spaCy}
 \usage{
 spacy_initialize(model = "en", python_executable = NULL, ask = FALSE,
-  virtualenv = NULL, condaenv = NULL)
+  source_bash_profile = FALSE, virtualenv = NULL, condaenv = NULL)
 }
 \arguments{
 \item{model}{Language package for loading spacy. Example: \code{en} (English) and
@@ -17,6 +17,10 @@ spacy_initialize(model = "en", python_executable = NULL, ask = FALSE,
 if \code{TRUE}, list available spaCy installations and prompt the user 
 for which to use. If another (e.g. \code{python_executable}) is set, then 
 this value will always be treated as \code{FALSE}.}
+
+\item{source_bash_profile}{logical; if \code{TRUE}, source \code{~/.bash_profile} before trying
+to find python executables with spaCy installed. Most likely necessary to set \code{TRUE}, 
+if using anaconda python in Mac or Linux.}
 
 \item{virtualenv}{set a path to the python virtual environment with spaCy installed
 Example: \code{virtualenv = "~/myenv"}}

--- a/man/spacy_initialize.Rd
+++ b/man/spacy_initialize.Rd
@@ -5,7 +5,7 @@
 \title{Initialize spaCy}
 \usage{
 spacy_initialize(model = "en", python_executable = NULL, ask = FALSE,
-  source_bash_profile = FALSE, virtualenv = NULL, condaenv = NULL)
+  source_bash_profile = NULL, virtualenv = NULL, condaenv = NULL)
 }
 \arguments{
 \item{model}{Language package for loading spacy. Example: \code{en} (English) and
@@ -20,7 +20,9 @@ this value will always be treated as \code{FALSE}.}
 
 \item{source_bash_profile}{logical; if \code{TRUE}, source \code{~/.bash_profile} before trying
 to find python executables with spaCy installed. Most likely necessary to set \code{TRUE}, 
-if using anaconda python in Mac or Linux.}
+if using anaconda python in Mac or Linux. Default is \code{NULL} 
+which functions as \code{TRUE} for non-Windows system (e.g. Mac/Linux) and 
+\code{FALSE} for Windows system.}
 
 \item{virtualenv}{set a path to the python virtual environment with spaCy installed
 Example: \code{virtualenv = "~/myenv"}}


### PR DESCRIPTION
Related to #81 

This PR includes a new option for spacy_initialize for checking/sourcing `.bash_profile` before running  `which` to find python executables with spacy. In my environment, the package can detect anaconda python (Python 3.6) when the option `source_bash_profile = TRUE`.

**EDITED** 
I made further update on the repository to address the discussion below and #81 
- The default option for `source_bash_profile` is now `NULL` which works as `TRUE` for Mac/Linux users (`FALSE` for Windows users)
- The package now uses `options()` and users can permanently set the option for spacy python (see https://github.com/kbenoit/spacyr/blob/source-bash-profile/README.Rmd#permanently-set-the-default-python)