### PR TITLE
Add \url{} and add link to annotation specifications

### DIFF
--- a/R/spacy_parse.R
+++ b/R/spacy_parse.R
@@ -11,10 +11,12 @@
 #' @param x a character object, a \pkg{quanteda} corpus, or a TIF-compliant
 #'   corpus data.frame (see \url{https://github.com/ropensci/tif})
 #' @param pos logical whether to return universal dependency POS tagset
-#'   (http://universaldependencies.org/u/pos/all.html)
+#'   \url{http://universaldependencies.org/u/pos/})
 #' @param tag logical whether to return detailed part-of-speech tags, for the
 #'   langage model \code{en}, it uses the OntoNotes 5 version of the Penn
-#'   Treebank tag set (https://spacy.io/docs/usage/pos-tagging#pos-schemes)
+#'   Treebank tag set (\url{https://spacy.io/docs/usage/pos-tagging#pos-schemes}). 
+#' Annotation specifications for other available languages are available on the 
+#' spaCy website (\url{https://spacy.io/api/annotation}).
 #' @param lemma logical; inlucde lemmatized tokens in the output (lemmatization 
 #'   may not work properly for non-English models)
 #' @param entity logical; if \code{TRUE}, report named entities


### PR DESCRIPTION
Fix broken link to the Universal POS tags and add reference to the overview of annotation specifications for various spaCy language models.